### PR TITLE
ignore meta files of unity packages

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -59,6 +59,7 @@ sysinfo.txt
 *.apk
 *.aab
 *.unitypackage
+*.unitypackage.meta
 *.app
 
 # Crashlytics generated file


### PR DESCRIPTION
Unity packages were already ignored in this template, but it seems in recent versions of Unity these also generate meta files for these. If the meta file isn't also ignored, the person who imports an asset containing a .unitypackage file could accidentally commit the meta files. For another who downloads those meta files, Unity would automatically delete them since they don't have the .unitypackage. The the importer commits them again and the cycle goes on and on until someone like me gets fed up.

This fixes that inconsistency by adding the *.unitypackage.meta to the ignore list.